### PR TITLE
Next

### DIFF
--- a/draft-scurtescu-secevent-simple-control-plane.md
+++ b/draft-scurtescu-secevent-simple-control-plane.md
@@ -1,8 +1,7 @@
----
-title: Simple Control Plane for SET Delivery
-abbrev: simple-control-plane
+--- title: Control Plane for SET Delivery
+abbrev: set-control-plane
 docname: draft-scurtescu-secevent-simple-control-plane-00
-date: 2017-05-10
+date: 2017-05-31
 category: info
 ipr: trust200902
 
@@ -26,20 +25,23 @@ author:
     email: richanna@amazon.com
     
 normative:
+ RFC7159:
  RFC7519:
 
 --- abstract
 
-SET (Secutity Event Token) delivery requires a control plane to get or update
-the stream status, to add or remove subjects and to trigger verification
-events. This specification defines a plain REST API that implements a basic
-control plane. The main purpose of this specification is to offer a comparison
-to a similar SCIM REST API.
+Security Event Token (SET) delivery requires event receivers to indicate
+to event transmitters the subjects about which they wish to receive
+events, and how they wish to them. This specification defines a REST
+API for a basic control plane that event transmitters can implement and
+event receivers may use to manage the flow of events from one to the
+other.
 
 --- middle
 
 Introduction {#intro}
 ============
+<<TODO>>
 
 Notational Conventions {#conv}
 ======================
@@ -49,33 +51,42 @@ document are to be interpreted as described in {{!RFC2119}}.
 
 Control Plane Resources {#resources}
 =======================
-Event receivers interact with a stream's control plane through
-RESTful calls to resources under the stream's stream control
-endpoint.
-
+Event receivers manage how they receive events and the subjects about
+which they want to receive events by making HTTP requests to resources
+that collectively make up the SET Control Plane.
 
 Stream {#stream}
 ----------------
 A stream represents a configured relationship between a single
 event transmitter and a single event receiver, and describes which
 events the transmitter may transmit to the receiver and how the
-receiver may receive those events. Transmitters MAY support multiple
-streams for the same receiver. Transmitters MAY assign distinct URLs
-for different streams, and/or provide a single URL for all streams
-(e.g. if the transmitter can identify the stream from the credentials
-used to authenticate the request).
+receiver may receive those events. A stream's event transmitter
+transmits events over the stream to the stream's event receiver, making
+the events available to the event receiver in an agreed upon way as
+described by the stream's configuration.
+
+Transmitters MAY support multiple streams for the same receiver.
+Transmitters MAY also assign distinct URLs for different streams, and/or
+provide a single URL for multiple streams, provided that the transmitter
+has some mechanism through which they can identify the receiver and
+stream, e.g. from authentication credentials. The definition of such
+mechanisms is outside the scope of this specification.
+
+Event streams have the following properties:
 
 {: vspace="0"}
 aud
 : A string containing an audience claim as defined in [JSON Web Token
-  (JWT)](#RFC7519)
-  that identifies the event receiver for the stream.
+  (JWT)](#RFC7519) that identifies the event receiver for the stream.
 
 events
-: Optional. An array of URIs identifying the set of events which the
+: OPTIONAL. An array of URIs identifying the set of events which the
   transmitter may transmit over this stream. If omitted, transmitters
   SHOULD make this set available to the receiver via some other means
-  (e.g. publishing it in online documentation).
+  (e.g. publishing it in online documentation). The value of this
+  property is dictated by the transmitter, and therefore it SHALL be
+  omitted by the receiver when making requests to modify the stream's
+  configuration.
 
 transmission_method
 : A string indicating the mechanism by which the transmitter will
@@ -95,18 +106,21 @@ transmission_method
   made up?>>
 
 http_pull_url
-: Optional unless transmission_method is HTTP_PULL. The URL to which
-  the receiver will make requests in order to get events.
+: OPTIONAL unless transmission_method is HTTP_PULL. The URL to which
+  the receiver will make requests in order to get events. The value of
+  this property is dictated by the transmitter, and therefore it SHALL
+  be omitted by the receiver when making requests to modify the stream's
+  configuration.
 
 http_push_url
-: Optional unless transmission_method is HTTP_PUSH. The URL to which
+: OPTIONAL unless transmission_method is HTTP_PUSH. The URL to which
   the transmitter will send events when transmitting events to the
   receiver. 
 
-### Reading a Stream 
+### Reading a Stream's Configuration
 An event receiver gets the current configuration of a stream by making
 an HTTP GET request to the stream resource. On receiving a valid request
-the event transmitter responds with a 200 OK response containing a JSON
+the event transmitter responds with a 200 OK response containing a [JSON](#RFC7159)
 representation of the stream's configuration in the body.
 
 The following is a non-normative example request to read a stream's
@@ -116,20 +130,21 @@ configuration:
 GET /streams/risc HTTP/1.1
 Host: transmitter.example.com
 Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
+
 ~~~
 
 The following is a non-normative example response:
 
 ~~~
 HTTP/1.1 200 OK
-Content-Type: application/json
+Content-Type: application/json; charset=UTF-8
 Cache-Control: no-store
 Pragma: no-cache
 
 {
   "aud": "http://www.example.com",
-  "transmission_method": "HTTP_PUSH",
-  "http_push_url": "https://receiver.example.com/event_receiver/risc",
+  "transmission_method": "HTTP_PULL",
+  "http_push_url": "https://transmitter.example.com/events/risc",
   "events": [
     "https://schemas.openid.net/risc/event-type/account-at-risk",
     "https://schemas.openid.net/risc/event-type/account-deleted",
@@ -143,35 +158,99 @@ Pragma: no-cache
 }
 ~~~
 
-Subject {#subject}
-------------------
-Each stream has a set of subject subresources which indicates the
-subjects about which events may be transmitted over the stream. Event
-receivers manipulate this set to signal to the transmitter which
-subjects the receiver wishes to receive events about.
+### Modifying a Stream's Configuration
+An event receiver modifies the configuration of an event stream by
+making an HTTP POST request to the stream's resource, with the desired
+changes expressed as a JSON object in the request body. On a successful
+response, the event transmitter responds with a 200 OK response
+containing the stream's modified configuration.
 
-<<TODO: Add attributes corresponding to claims?>>
+The following is a non-normative example request:
 
-### Adding a Subject
+~~~
+POST /streams/risc HTTP/1.1
+Host: transmitter.example.com
+Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
+Content-Type: application/json; charset=UTF-8
+
+{
+  "aud": "http://www.example.com",
+  "transmission_method": "HTTP_PUSH",
+  "http_push_url": "https://receiver.example.com/event_receiver/risc",
+}
+
+~~~
+
+The following is a non-normative example response:
+
+~~~
+HTTP/1.1 200 OK
+Server: transmitter.example.com
+Cache-Control: no-store
+Pragma: no-cache
+
+~~~
+
+Subjects {#subjects}
+--------------------
+Each stream has a set of subjects, entities or objects about which the
+event transmitter may transmit events over the stream. Event receivers
+can manipulate this set to manage which subjects they may receive events
+about over the stream.
+
+As the nature of the subject of a SET is left up to profiling
+specifications to define, subject identifiers are out of scope for this
+specification. Profiling specifications MUST define one or more subject
+properties that a receiver can include in their requests in order to
+identify the subject the request pertains to. 
+
+<<TODO: richanna: I think this spec should go further and require
+standardized representations for subject identifiers, e.g. so subjects
+identified by phone number look the same in the control plane for
+profiling spec A and profiling spec B. I want second opinions before
+writing this up, though.>>
+
+Profiling specifications MAY define additional subject properties. Event
+transmitters MUST reject any request containing subject properties that
+it does not understand or that are undefined for the events that may be
+transmitted over the stream.
+
+In addition to properties defined in profiling specifications, all
+subjects have the following properties:
+
+{: vspace="0"}
+transmit_events
+: A boolean indicating whether or not the receiver wants to receive
+  events about the subject.
+
+### Adding a Subject to a Stream
 When a receiver wants to signal to a transmitter that they wish to
 receive events about a particular subject over a stream, the receiver
-makes an HTTP PUT request to the `/subjects` subresource of the stream.
-The transmitter MAY choose to ignore the request, for example if the
-subject has indicated to the transmitter that they do not want events to
-be transmitted to the receiver. On a successful response, the
-transmitter responds with a 200 OK response.
+makes an HTTP POST request to the stream's `/subjects` resource. The
+transmitter MAY choose to ignore the request, for example if the subject
+has previously indicated to the transmitter that they do not want events
+to be transmitted to the receiver. On a successful response, the
+transmitter responds with an empty 200 OK response.
+
+<<TODO: MUST transmitters indicate that they are ignoring the request?>>
+
+<<TODO: Errors>>
 
 The following is a non-normative example request to add a subject to a
 stream:
 
 ~~~
-PUT /streams/risc/subjects HTTP/1.1
+POST /streams/risc/subjects HTTP/1.1
 Host: transmitter.example.com
 Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
 
 {
-  "iss": "http://transmitter.example.com",
-  "sub": "1234567"
+  sub_type: "http://www.openid.net/events/sub_types/oidc",
+  sub: {
+    "iss": "http://transmitter.example.com",
+    "sub": "1234567"
+  },
+  "transmit_events": true
 }
 ~~~
 
@@ -188,11 +267,11 @@ Pragma: no-cache
 ### Removing a Subject
 When a receiver wants to signal to a transmitter that the receiver no
 longer wishes to receive events about a subject over a stream, the
-receiver makes an HTTP POST request to the `/subjects` subresource of
-the stream. The transmitter MAY choose to ignore the request, for
-example if the subject has indicated to the transmitter that they do not
-want events to be transmitted to the receiver. On a successful response,
-the transmitter responds with a 204 (No Content) response.
+receiver makes an HTTP POST request to the stream's `/subjects`
+resource. On a successful response, the transmitter responds with a
+204 No Conten) response.
+
+<<TODO: Errors>>
 
 The following is a non-normative example request to remove a subject
 from a stream:
@@ -201,11 +280,14 @@ from a stream:
 POST /streams/risc/subjects HTTP/1.1
 Host: transmitter.example.com
 Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
-Content-Type: application/json
+Content-Type: application/json; charset=UTF-8
 
 {
-  "iss": "http://transmitter.example.com",
-  "sub": "1234567",
+  sub_type: "http://www.openid.net/events/sub_types/oidc",
+  sub: {
+    "iss": "http://transmitter.example.com",
+    "sub": "1234567"
+  },
   "receive_events": false
 }
 ~~~
@@ -223,10 +305,62 @@ Pragma: no-cache
 
 Verification {#verify}
 ----------------------
+In some cases, the frequency of event transmission on a stream will be
+very low, making it difficult for an event receiver to tell the
+difference between expected behavior and event transmission failure due
+to a misconfigured stream. Event receivers can use a stream's
+`/verification` resource to request that a verification event be
+transmitted over the stream, allowing the receiver to confirm that the
+stream is configured correctly upon successful receipt of the event.
+
+{: vspace="0"}
+state
+: OPTIONAL. An arbitrary string that the transmitter MUST echo back to
+  the receiver in the verification event's payload. Receivers MAY use
+  the value of this parameter to correlate a verification event with a
+  verification request.
 
 ### Triggering a Verification Event.
+To request that a verification event be sent over a stream, the event
+receiver makes an HTTP POST request to the stream's `/verification`
+subresource, with a JSON object containing the parameters of the
+verification request, if any. On a successful request, the event
+transmitter responds with an empty 204 No Content response.
 
-#### Successful Response
+A successful response from a POST to the `/verification` subresource
+does not indicate that the verification event was transmitted
+successfully, only that the transmitter has transmitted the event or
+will do so at some point in the future. Transmitters MAY transmit the
+event via an asynchronous process, and SHOULD publish an SLA for
+verification event transmission times. Receivers MUST NOT depend on the
+verification event being transmitted synchonrously with their request.
+
+<<TODO: Errors>>
+
+The following is a non-normative example request to trigger a
+verification event:
+
+~~~
+POST /streams/risc/verification HTTP/1.1
+Host: transmitter.example.com
+Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
+Content-Type: application/json; charset=UTF-8
+
+{
+  state: "VGhpcyBpcyBhbiBleGFtcGxlIHN0YXRlIHZhbHVlLgo="
+}
+~~~
+
+The following is a non-normative example response to a successful
+response:
+
+~~~
+HTTP/1.1 204 No Content
+Server: transmitter.example.com
+Cache-Control: no-store
+Pragma: no-cache
+
+~~~
 
 --- back
 

--- a/draft-scurtescu-secevent-simple-control-plane.md
+++ b/draft-scurtescu-secevent-simple-control-plane.md
@@ -26,8 +26,10 @@ author:
     email: richanna@amazon.com
     
 normative:
- RFC7159:
- RFC7519:
+  RFC7159:
+  RFC7519:
+  set-delivery:
+    title: <<TODO>>
 
 --- abstract
 
@@ -52,9 +54,9 @@ document are to be interpreted as described in {{!RFC2119}}.
 
 Control Plane Resources {#resources}
 =======================
-Event receivers manage how they receive events and the subjects about
-which they want to receive events by making HTTP requests to resources
-that collectively make up the SET Control Plane.
+Event receivers manage how they receive events and the subjects about which
+they want to receive events by making HTTP requests to resources that
+collectively make up the SET Control Plane.
 
 Stream {#stream}
 ----------------
@@ -81,42 +83,23 @@ aud
   (JWT)](#RFC7519) that identifies the event receiver for the stream.
 
 events
-: OPTIONAL. An array of URIs identifying the set of events which the
-  transmitter may transmit over this stream. If omitted, transmitters
-  SHOULD make this set available to the receiver via some other means
-  (e.g. publishing it in online documentation). The value of this
-  property is dictated by the transmitter, and therefore it SHALL be
-  omitted by the receiver when making requests to modify the stream's
-  configuration.
+: OPTIONAL. An array of URIs identifying the set of events which MAY be
+delivered over the event stream. If omitted, transmitters SHOULD make this
+set available to the receiver via some other means (e.g. publishing it in
+online documentation). The value of this property is dictated by the
+transmitter, and therefore it SHALL be omitted by the receiver when making
+requests to modify the stream's configuration.
 
-transmission_method
-: A string indicating the mechanism by which the transmitter will
-  transmit events to the receiver. Allowed values are:
-  
-  {: vspace="0"}
-  HTTP_PUSH
-  : The transmitter will send events to the receiver via
-    HTTP POST requests to the stream's http_push_url.
+delivery_methods
+: A JSON object containing a set of name/value pairs, where the name is a
+URI identifying a SET delivery method as defined in [SET Delivery](#set-delivery), and
+the value is a JSON object whose name/value pairs contain the additional
+configuration parameters for that SET delivery method. The value object may
+be an empty JSON object (e.g. `{}`) if the SET delivery method does not have
+any configuration parameters.
 
-  HTTP_PULL
-  : The receiver will periodically make HTTP GET requests to
-    the stream's http_pull_url to get new events.
-  
-  <<TODO: (richanna) These should reference the distribution spec.>>\\
-  <<TODO: (richanna) Should these be UR\[ILN]s instead of strings I
-  made up?>>
-
-http_pull_url
-: OPTIONAL unless transmission_method is HTTP_PULL. The URL to which
-  the receiver will make requests in order to get events. The value of
-  this property is dictated by the transmitter, and therefore it SHALL
-  be omitted by the receiver when making requests to modify the stream's
-  configuration.
-
-http_push_url
-: OPTIONAL unless transmission_method is HTTP_PUSH. The URL to which
-  the transmitter will send events when transmitting events to the
-  receiver. 
+<<TODO: Update with actual SET delivery reference, or drop reference if we
+merge docs.>>
 
 ### Reading a Stream's Configuration
 An event receiver gets the current configuration of a stream by making
@@ -144,8 +127,14 @@ Pragma: no-cache
 
 {
   "aud": "http://www.example.com",
-  "transmission_method": "HTTP_PULL",
-  "http_push_url": "https://transmitter.example.com/events/risc",
+  "delivery_methods": {
+    "https://schemas.example.com/set/http-push": {
+      "url": "https://receiver.example.com/events/risc"
+    },
+    "https://schemas.example.com/set/http-pull": {
+      "url": "https://transmitter.example.com/events/risc"
+    }
+  },
   "events": [
     "https://schemas.openid.net/risc/event-type/account-at-risk",
     "https://schemas.openid.net/risc/event-type/account-deleted",
@@ -157,39 +146,6 @@ Pragma: no-cache
     "https://schemas.openid.net/risc/event-type/tokens-revoked"
   ]
 }
-~~~
-
-### Modifying a Stream's Configuration
-An event receiver modifies the configuration of an event stream by
-making an HTTP POST request to the stream's resource, with the desired
-changes expressed as a JSON object in the request body. On a successful
-response, the event transmitter responds with a 200 OK response
-containing the stream's modified configuration.
-
-The following is a non-normative example request:
-
-~~~
-POST /streams/risc HTTP/1.1
-Host: transmitter.example.com
-Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
-Content-Type: application/json; charset=UTF-8
-
-{
-  "aud": "http://www.example.com",
-  "transmission_method": "HTTP_PUSH",
-  "http_push_url": "https://receiver.example.com/event_receiver/risc",
-}
-
-~~~
-
-The following is a non-normative example response:
-
-~~~
-HTTP/1.1 200 OK
-Server: transmitter.example.com
-Cache-Control: no-store
-Pragma: no-cache
-
 ~~~
 
 Subjects {#subjects}

--- a/draft-scurtescu-secevent-simple-control-plane.md
+++ b/draft-scurtescu-secevent-simple-control-plane.md
@@ -219,14 +219,14 @@ the receiver that the request was ignored.
 
 Errors are signaled with HTTP staus codes as follows:
 
-* 400 - if the request body cannot be parsed or of the request is otherwise
-  invalid
-* 401 - if authorization failed or it is missing
-* 403 - if the Event Receiver is not allowed to add this particular subject
-* 404 - if the subject is not recognized by the Event Transmitter, the Event
-  Transmitter may chose to stay silent in this case and responde with 200
-* 429 - if the Event Receiver is sending too many requests in a gvien amount
-  of time
+| Code | Description |
+|------+-------------|
+| 400  | if the request body cannot be parsed or if the request is otherwise invalid |
+| 401  | if authorization failed or it is missing |
+| 403  | if the Event Receiver is not allowed to add this particular subject |
+| 404  | if the subject is not recognized by the Event Transmitter, the Event Transmitter may chose to stay silent in this case and responde with 200 |
+| 429  | if the Event Receiver is sending too many requests in a gvien amount of time |
+{: #tabadderr title="Add Subject Errors"}
 
 The following is a non-normative example request to add a subject to a
 stream, where the subject is identified by OpenID Connect iss and sub
@@ -261,14 +261,14 @@ response, the Event Transmitter responds with a 204 No Content response.
 
 Errors are signaled with HTTP staus codes as follows:
 
-* 400 - if the request body cannot be parsed or of the request is otherwise
-  invalid
-* 401 - if authorization failed or it is missing
-* 403 - if the Event Receiver is not allowed to remove this particular subject
-* 404 - if the subject is not recognized by the Event Transmitter, the Event
-  Transmitter may chose to stay silent in this case and responde with 204
-* 429 - if the Event Receiver is sending too many requests in a gvien amount
-  of time
+| Code | Description |
+|------+-------------|
+| 400  | if the request body cannot be parsed or if the request is otherwise invalid |
+| 401  | if authorization failed or it is missing |
+| 403  | if the Event Receiver is not allowed to remove this particular subject |
+| 404  | if the subject is not recognized by the Event Transmitter, the Event Transmitter may chose to stay silent in this case and responde with 204 |
+| 429  | if the Event Receiver is sending too many requests in a gvien amount of time |
+{: #tabremoveerr title="Remove Subject Errors"}
 
 The following is a non-normative example request where the subject is
 identified by an email claim:
@@ -329,11 +329,12 @@ transmitted synchonrously with their request.
 
 Errors are signaled with HTTP staus codes as follows:
 
-* 400 - if the request body cannot be parsed or of the request is otherwise
-  invalid
-* 401 - if authorization failed or it is missing
-* 429 - if the Event Receiver is sending too many requests in a gvien amount
-  of time
+| Code | Description |
+|------+-------------|
+| 400  | if the request body cannot be parsed or if the request is otherwise invalid |
+| 401  | if authorization failed or it is missing |
+| 429  | if the Event Receiver is sending too many requests in a gvien amount of time |
+{: #taberifyerr title="Verification Errors"}
 
 The following is a non-normative example request to trigger a verification
 event:

--- a/draft-scurtescu-secevent-simple-control-plane.md
+++ b/draft-scurtescu-secevent-simple-control-plane.md
@@ -177,12 +177,14 @@ When a receiver wants to signal to a transmitter that they wish to receive
 events about a particular subject over a stream, the receiver makes an HTTP
 POST request to the `/add-subjects` endpoint under the stream's resource,
 containing in the body a Subject Identifier Object identifying the subject
-to be added. The transmitter MAY choose to ignore the request, for example
-if the subject has previously indicated to the transmitter that they do not
-want events to be transmitted to the receiver. On a successful response, the
-transmitter responds with an empty 200 OK response.
+to be added. On a successful response, the transmitter responds with an
+empty 200 OK response.
 
-<<TODO: MUST transmitters indicate that they are ignoring the request?>>
+The transmitter MAY choose to silently ignore the request, for example if
+the subject has previously indicated to the transmitter that they do not
+want events to be transmitted to the receiver. In this case, the transmitter
+MUST return an empty 200 OK response, and MUST NOT indicate to the receiver
+that the request was ignored.
 
 <<TODO: Errors>>
 

--- a/draft-scurtescu-secevent-simple-control-plane.md
+++ b/draft-scurtescu-secevent-simple-control-plane.md
@@ -57,16 +57,16 @@ add and remove subjects and to trigger verification.
 ~~~
 +------------+                +------------+
 |            | Stream Status  |            |
-| Event      &lt;----------------+ Event      |
+| Event      <----------------+ Event      |
 | Stream     |                | Receiver   |
 | Management | Add Subject    |            |
-| API        &lt;----------------+            |
+| API        <----------------+            |
 |            |                |            |
 |            | Remove Subject |            |
-|            &lt;----------------+            |
+|            <----------------+            |
 |            |                |            |
 |            | Verification   |            |
-|            &lt;----------------+            |
+|            <----------------+            |
 |            |                |            |
 +------------+                +------------+
 ~~~

--- a/draft-scurtescu-secevent-simple-control-plane.md
+++ b/draft-scurtescu-secevent-simple-control-plane.md
@@ -1,4 +1,5 @@
---- title: Control Plane for SET Delivery
+---
+title: Control Plane for SET Delivery
 abbrev: set-control-plane
 docname: draft-scurtescu-secevent-simple-control-plane-00
 date: 2017-05-31

--- a/draft-scurtescu-secevent-simple-control-plane.md
+++ b/draft-scurtescu-secevent-simple-control-plane.md
@@ -50,7 +50,30 @@ other.
 
 Introduction {#intro}
 ============
-<<TODO>>
+This specification defines an HTTP API to be implemented by Event Transmitters
+and that can be used by Event Receivers to query the Event Stream status, to
+add and remove subjects and to trigger verification.
+
+~~~
++------------+                +------------+
+|            | Stream Status  |            |
+| Event      &lt;----------------+ Event      |
+| Stream     |                | Receiver   |
+| Management | Add Subject    |            |
+| API        &lt;----------------+            |
+|            |                |            |
+|            | Remove Subject |            |
+|            &lt;----------------+            |
+|            |                |            |
+|            | Verification   |            |
+|            &lt;----------------+            |
+|            |                |            |
++------------+                +------------+
+~~~
+{: #figintro title="Event Stream Management API"}
+
+This spec does not define how events are delivered or what the structure of the
+events is and is out of scope for this specification.
 
 Notational Conventions {#conv}
 ======================

--- a/draft-scurtescu-secevent-simple-control-plane.md
+++ b/draft-scurtescu-secevent-simple-control-plane.md
@@ -2,7 +2,7 @@
 title: Management API for SET Event Streams
 abbrev: set-control-plane
 docname: draft-scurtescu-secevent-simple-control-plane-00
-date: 2017-05-31
+date: 2017-06-13
 category: info
 ipr: trust200902
 

--- a/draft-scurtescu-secevent-simple-control-plane.md
+++ b/draft-scurtescu-secevent-simple-control-plane.md
@@ -161,57 +161,37 @@ specification. Profiling specifications MUST define one or more subject
 properties that a receiver can include in their requests in order to
 identify the subject the request pertains to. 
 
-<<TODO: richanna: I think this spec should go further and require
-standardized representations for subject identifiers, e.g. so subjects
-identified by phone number look the same in the control plane for
-profiling spec A and profiling spec B. I want second opinions before
-writing this up, though.>>
-
-Profiling specifications MAY define additional subject properties. Event
-transmitters MUST reject any request containing subject properties that
-it does not understand or that are undefined for the events that may be
-transmitted over the stream.
-
-In addition to properties defined in profiling specifications, all
-subjects have the following properties:
-
-{: vspace="0"}
-transmit_events
-: A boolean indicating whether or not the receiver wants to receive
-  events about the subject.
-
 ### Adding a Subject to a Stream
 When a receiver wants to signal to a transmitter that they wish to
 receive events about a particular subject over a stream, the receiver
-makes an HTTP POST request to the stream's `/subjects` resource. The
-transmitter MAY choose to ignore the request, for example if the subject
-has previously indicated to the transmitter that they do not want events
-to be transmitted to the receiver. On a successful response, the
-transmitter responds with an empty 200 OK response.
+makes an HTTP POST request to the `/add-subjects` endpoint under the
+stream's resource, containing in the body a JSON object whose name/value
+pairs contain subject identifiers defined by a profiling specification. The
+transmitter MAY choose to ignore the request, for example if the subject has
+previously indicated to the transmitter that they do not want events to be
+transmitted to the receiver. On a successful response, the transmitter
+responds with an empty 200 OK response.
 
 <<TODO: MUST transmitters indicate that they are ignoring the request?>>
 
 <<TODO: Errors>>
 
 The following is a non-normative example request to add a subject to a
-stream:
+stream, where the subject is identified by OpenID Connect iss and sub
+claims:
 
 ~~~
-POST /streams/risc/subjects HTTP/1.1
+POST /streams/risc/add-subject HTTP/1.1
 Host: transmitter.example.com
 Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
 
 {
-  sub_type: "http://www.openid.net/events/sub_types/oidc",
-  sub: {
-    "iss": "http://transmitter.example.com",
-    "sub": "1234567"
-  },
-  "transmit_events": true
+  "iss": "http://account.example.com",
+  "sub": "1234567"
 }
 ~~~
 
-The following is a non-normative example response:
+The following is a non-normative example response to a successful request:
 
 ~~~
 HTTP/1.1 200 OK
@@ -224,33 +204,28 @@ Pragma: no-cache
 ### Removing a Subject
 When a receiver wants to signal to a transmitter that the receiver no
 longer wishes to receive events about a subject over a stream, the
-receiver makes an HTTP POST request to the stream's `/subjects`
-resource. On a successful response, the transmitter responds with a
-204 No Conten) response.
+receiver makes an HTTP POST request to the `/remove-subject` endpoint under
+the stream's resource, containing in the body a JSON object whose name/value
+pairs contain subject identifiers defined by a profiling specification. The
+On a successful response, the transmitter responds with a 204 No Content
+response.
 
 <<TODO: Errors>>
 
-The following is a non-normative example request to remove a subject
-from a stream:
+The following is a non-normative example request where the subject is
+identified by an email claim:
 
 ~~~
-POST /streams/risc/subjects HTTP/1.1
+POST /streams/risc/remove-subject HTTP/1.1
 Host: transmitter.example.com
 Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
-Content-Type: application/json; charset=UTF-8
 
 {
-  sub_type: "http://www.openid.net/events/sub_types/oidc",
-  sub: {
-    "iss": "http://transmitter.example.com",
-    "sub": "1234567"
-  },
-  "receive_events": false
+  "email": "example.user@example.com"
 }
 ~~~
 
-The following is a non-normative example response to a successful
-response:
+The following is a non-normative example response to a successful request:
 
 ~~~
 HTTP/1.1 204 No Content
@@ -263,12 +238,12 @@ Pragma: no-cache
 Verification {#verify}
 ----------------------
 In some cases, the frequency of event transmission on a stream will be
-very low, making it difficult for an event receiver to tell the
-difference between expected behavior and event transmission failure due
-to a misconfigured stream. Event receivers can use a stream's
-`/verification` resource to request that a verification event be
-transmitted over the stream, allowing the receiver to confirm that the
-stream is configured correctly upon successful receipt of the event.
+very low, making it difficult for an event receiver to tell the difference
+between expected behavior and event transmission failure due to a
+misconfigured stream. Event receivers can use a stream's `/verification`
+resource to request that a verification event be transmitted over the
+stream, allowing the receiver to confirm that the stream is configured
+correctly upon successful receipt of the event.
 
 {: vspace="0"}
 state

--- a/draft-scurtescu-secevent-simple-control-plane.md
+++ b/draft-scurtescu-secevent-simple-control-plane.md
@@ -72,8 +72,8 @@ add and remove subjects and to trigger verification.
 ~~~
 {: #figintro title="Event Stream Management API"}
 
-This spec does not define how events are delivered or what the structure of the
-events is and is out of scope for this specification.
+How events are delivered and the structure of events are not in scope for this
+specification.
 
 Notational Conventions {#conv}
 ======================
@@ -96,7 +96,7 @@ Event Stream
   single Event Receiver.
 
 Event Stream Management Endpoint
-: A URL hosted by the transmitter, which serves as the stream
+: A URL hosted by the transmitter; it serves as the stream
   management API for a stream. An Event Transmitter MAY use a single
   Management Endpoint for multiple streams, provided that the transmitter
   has some mechanism through which they can identify the applicable stream
@@ -122,8 +122,8 @@ Subject Identifier Object
   SHOULD be declared as an acceptable way to identify subjects of SETs by
   one or more specifications that profile [SET](#SET).
 
-Verificatio Event
-: A special evet type for testing Event Streams. Receivers can request
+Verification Event
+: A special event type for testing Event Streams. Receivers can request
   such an event through the Verification Endpoint. Transmitters can
   periodically send these events to ensure the connection is alive.
 
@@ -229,8 +229,7 @@ Errors are signaled with HTTP staus codes as follows:
 {: #tabadderr title="Add Subject Errors"}
 
 The following is a non-normative example request to add a subject to a
-stream, where the subject is identified by OpenID Connect iss and sub
-claims:
+stream, where the subject is identified by an OpenID Connect email claim:
 
 ~~~
 POST /set/subjects:add HTTP/1.1
@@ -271,7 +270,7 @@ Errors are signaled with HTTP staus codes as follows:
 {: #tabremoveerr title="Remove Subject Errors"}
 
 The following is a non-normative example request where the subject is
-identified by an email claim:
+identified by a phone_number claim:
 
 ~~~
 POST /set/subjects:remove HTTP/1.1
@@ -319,13 +318,13 @@ object containing the parameters of the verification request, if any. On a
 successful request, the event transmitter responds with an empty 204 No Content
 response.
 
-A successful response from a POST to the Verification` Endpoint does not
+A successful response from a POST to the Verification Endpoint does not
 indicate that the verification event was transmitted successfully, only that
 the Event Transmitter has transmitted the event or will do so at some point
 in the future. Event Transmitters MAY transmit the event via an asynchronous
 process, and SHOULD publish an SLA for verification event transmission
 times. Event Receivers MUST NOT depend on the verification event being
-transmitted synchonrously with their request.
+transmitted synchronously with their request.
 
 Errors are signaled with HTTP staus codes as follows:
 

--- a/draft-scurtescu-secevent-simple-control-plane.md
+++ b/draft-scurtescu-secevent-simple-control-plane.md
@@ -193,7 +193,16 @@ want events to be transmitted to the Event Receiver. In this case, the
 transmitter MUST return an empty 200 OK response, and MUST NOT indicate to
 the receiver that the request was ignored.
 
-<<TODO: Errors>>
+Errors are signaled with HTTP staus codes as follows:
+
+* 400 - if the request body cannot be parsed or of the request is otherwise
+  invalid
+* 401 - if authorization failed or it is missing
+* 403 - if the Event Receiver is not allowed to add this particular subject
+* 404 - if the subject is not recognized by the Event Transmitter, the Event
+  Transmitter may chose to stay silent in this case and responde with 200
+* 429 - if the Event Receiver is sending too many requests in a gvien amount
+  of time
 
 The following is a non-normative example request to add a subject to a
 stream, where the subject is identified by OpenID Connect iss and sub
@@ -226,7 +235,16 @@ POST request to the Remove Subject Endpoint, containing in the body a Subject
 Identifier Object identifying the subject to be removed. On a successful
 response, the Event Transmitter responds with a 204 No Content response.
 
-<<TODO: Errors>>
+Errors are signaled with HTTP staus codes as follows:
+
+* 400 - if the request body cannot be parsed or of the request is otherwise
+  invalid
+* 401 - if authorization failed or it is missing
+* 403 - if the Event Receiver is not allowed to remove this particular subject
+* 404 - if the subject is not recognized by the Event Transmitter, the Event
+  Transmitter may chose to stay silent in this case and responde with 204
+* 429 - if the Event Receiver is sending too many requests in a gvien amount
+  of time
 
 The following is a non-normative example request where the subject is
 identified by an email claim:
@@ -284,7 +302,13 @@ process, and SHOULD publish an SLA for verification event transmission
 times. Event Receivers MUST NOT depend on the verification event being
 transmitted synchonrously with their request.
 
-<<TODO: Errors>>
+Errors are signaled with HTTP staus codes as follows:
+
+* 400 - if the request body cannot be parsed or of the request is otherwise
+  invalid
+* 401 - if authorization failed or it is missing
+* 429 - if the Event Receiver is sending too many requests in a gvien amount
+  of time
 
 The following is a non-normative example request to trigger a verification
 event:

--- a/draft-scurtescu-secevent-simple-control-plane.md
+++ b/draft-scurtescu-secevent-simple-control-plane.md
@@ -214,8 +214,7 @@ Host: transmitter.example.com
 Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
 
 {
-  "iss": "http://account.example.com",
-  "sub": "1234567"
+  "email": "example.user@example.com"
 }
 ~~~
 
@@ -255,7 +254,7 @@ Host: transmitter.example.com
 Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
 
 {
-  "email": "example.user@example.com"
+  "phone_number": "123-456-7890"
 }
 ~~~
 

--- a/draft-scurtescu-secevent-simple-control-plane.md
+++ b/draft-scurtescu-secevent-simple-control-plane.md
@@ -319,7 +319,7 @@ Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
 Content-Type: application/json; charset=UTF-8
 
 {
-  state: "VGhpcyBpcyBhbiBleGFtcGxlIHN0YXRlIHZhbHVlLgo="
+  "state": "VGhpcyBpcyBhbiBleGFtcGxlIHN0YXRlIHZhbHVlLgo="
 }
 ~~~
 
@@ -330,6 +330,24 @@ HTTP/1.1 204 No Content
 Server: transmitter.example.com
 Cache-Control: no-store
 Pragma: no-cache
+
+~~~
+
+And the following is a non-normative example of a verification event sent to
+the Event Receiver as a result of the above request:
+
+~~~
+{
+  "jti": "123456",
+  "iss": "https://transmitter.example.com",
+  "aud": "receiver.example.com",
+  "iat": "1493856000",
+  "events": [
+    "urn:ietf:params:secevent:event-type:core:verify" : {
+      "state": "VGhpcyBpcyBhbiBleGFtcGxlIHN0YXRlIHZhbHVlLgo=",
+    },
+  ],
+}
 
 ~~~
 

--- a/draft-scurtescu-secevent-simple-control-plane.md
+++ b/draft-scurtescu-secevent-simple-control-plane.md
@@ -4,6 +4,7 @@ abbrev: simple-control-plane
 docname: draft-scurtescu-secevent-simple-control-plane-00
 date: 2017-05-10
 category: info
+ipr: trust200902
 
 area: Security
 workgroup: secevent
@@ -19,11 +20,14 @@ author:
     organization: Google
     email: mscurtescu@google.com
  -
-    ins: A. Richard
-    name: Annabelle Richard
+    ins: A. Backman
+    name: Annabelle Backman
     organization: Amazon
     email: richanna@amazon.com
     
+normative:
+ RFC7519:
+
 --- abstract
 
 SET (Secutity Event Token) delivery requires a control plane to get or update
@@ -37,24 +41,192 @@ to a similar SCIM REST API.
 Introduction {#intro}
 ============
 
-Control Plane Operations {#operations}
-========================
+Notational Conventions {#conv}
+======================
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+"SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in {{!RFC2119}}.
 
-Stream Status {#status}
--------------
+Control Plane Resources {#resources}
+=======================
+Event receivers interact with a stream's control plane through
+RESTful calls to resources under the stream's stream control
+endpoint.
 
-Add Subject {#add}
------------
 
-Remove Subject {#remove}
---------------
+Stream {#stream}
+----------------
+A stream represents a configured relationship between a single
+event transmitter and a single event receiver, and describes which
+events the transmitter may transmit to the receiver and how the
+receiver may receive those events. Transmitters MAY support multiple
+streams for the same receiver. Transmitters MAY assign distinct URLs
+for different streams, and/or provide a single URL for all streams
+(e.g. if the transmitter can identify the stream from the credentials
+used to authenticate the request).
 
-Trigger Verify Event {#verify}
---------------------
+{: vspace="0"}
+aud
+: A string containing an audience claim as defined in [JSON Web Token
+  (JWT)](#RFC7519)
+  that identifies the event receiver for the stream.
+
+events
+: Optional. An array of URIs identifying the set of events which the
+  transmitter may transmit over this stream. If omitted, transmitters
+  SHOULD make this set available to the receiver via some other means
+  (e.g. publishing it in online documentation).
+
+transmission_method
+: A string indicating the mechanism by which the transmitter will
+  transmit events to the receiver. Allowed values are:
+  
+  {: vspace="0"}
+  HTTP_PUSH
+  : The transmitter will send events to the receiver via
+    HTTP POST requests to the stream's http_push_url.
+
+  HTTP_PULL
+  : The receiver will periodically make HTTP GET requests to
+    the stream's http_pull_url to get new events.
+  
+  <<TODO: (richanna) These should reference the distribution spec.>>\\
+  <<TODO: (richanna) Should these be UR\[ILN]s instead of strings I
+  made up?>>
+
+http_pull_url
+: Optional unless transmission_method is HTTP_PULL. The URL to which
+  the receiver will make requests in order to get events.
+
+http_push_url
+: Optional unless transmission_method is HTTP_PUSH. The URL to which
+  the transmitter will send events when transmitting events to the
+  receiver. 
+
+### Reading a Stream 
+An event receiver gets the current configuration of a stream by making
+an HTTP GET request to the stream resource. On receiving a valid request
+the event transmitter responds with a 200 OK response containing a JSON
+representation of the stream's configuration in the body.
+
+The following is a non-normative example request to read a stream's
+configuration:
+
+~~~
+GET /streams/risc HTTP/1.1
+Host: transmitter.example.com
+Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
+~~~
+
+The following is a non-normative example response:
+
+~~~
+HTTP/1.1 200 OK
+Content-Type: application/json
+Cache-Control: no-store
+Pragma: no-cache
+
+{
+  "aud": "http://www.example.com",
+  "transmission_method": "HTTP_PUSH",
+  "http_push_url": "https://receiver.example.com/event_receiver/risc",
+  "events": [
+    "https://schemas.openid.net/risc/event-type/account-at-risk",
+    "https://schemas.openid.net/risc/event-type/account-deleted",
+    "https://schemas.openid.net/risc/event-type/account-locked",
+    "https://schemas.openid.net/risc/event-type/account-unlocked",
+    "https://schemas.openid.net/risc/event-type/client-credentials-
+        revoked",
+    "https://schemas.openid.net/risc/event-type/sessions-revoked",
+    "https://schemas.openid.net/risc/event-type/tokens-revoked"
+  ]
+}
+~~~
+
+Subject {#subject}
+------------------
+Each stream has a set of subject subresources which indicates the
+subjects about which events may be transmitted over the stream. Event
+receivers manipulate this set to signal to the transmitter which
+subjects the receiver wishes to receive events about.
+
+<<TODO: Add attributes corresponding to claims?>>
+
+### Adding a Subject
+When a receiver wants to signal to a transmitter that they wish to
+receive events about a particular subject over a stream, the receiver
+makes an HTTP PUT request to the `/subjects` subresource of the stream.
+The transmitter MAY choose to ignore the request, for example if the
+subject has indicated to the transmitter that they do not want events to
+be transmitted to the receiver. On a successful response, the
+transmitter responds with a 200 OK response.
+
+The following is a non-normative example request to add a subject to a
+stream:
+
+~~~
+PUT /streams/risc/subjects HTTP/1.1
+Host: transmitter.example.com
+Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
+
+{
+  "iss": "http://transmitter.example.com",
+  "sub": "1234567"
+}
+~~~
+
+The following is a non-normative example response:
+
+~~~
+HTTP/1.1 200 OK
+Server: transmitter.example.com
+Cache-Control: no-store
+Pragma: no-cache
+
+~~~
+
+### Removing a Subject
+When a receiver wants to signal to a transmitter that the receiver no
+longer wishes to receive events about a subject over a stream, the
+receiver makes an HTTP POST request to the `/subjects` subresource of
+the stream. The transmitter MAY choose to ignore the request, for
+example if the subject has indicated to the transmitter that they do not
+want events to be transmitted to the receiver. On a successful response,
+the transmitter responds with a 204 (No Content) response.
+
+The following is a non-normative example request to remove a subject
+from a stream:
+
+~~~
+POST /streams/risc/subjects HTTP/1.1
+Host: transmitter.example.com
+Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
+Content-Type: application/json
+
+{
+  "iss": "http://transmitter.example.com",
+  "sub": "1234567",
+  "receive_events": false
+}
+~~~
+
+The following is a non-normative example response to a successful
+response:
+
+~~~
+HTTP/1.1 204 No Content
+Server: transmitter.example.com
+Cache-Control: no-store
+Pragma: no-cache
+
+~~~
+
+Verification {#verify}
+----------------------
+
+### Triggering a Verification Event.
+
+#### Successful Response
 
 --- back
-
-Examples {#examples}
-========
-
 

--- a/draft-scurtescu-secevent-simple-control-plane.md
+++ b/draft-scurtescu-secevent-simple-control-plane.md
@@ -41,7 +41,7 @@ normative:
 
 Security Event Token (SET) delivery requires event receivers to indicate
 to event transmitters the subjects about which they wish to receive
-events, and how they wish to them. This specification defines an HTTP 
+events, and how they wish to receive them. This specification defines an HTTP 
 API for a basic control plane that event transmitters can implement and
 event receivers may use to manage the flow of events from one to the
 other.
@@ -69,7 +69,7 @@ Event Stream
   Transmitter and a single Event Receiver, describing one or more methods by
   which the Event Transmitter may deliver SETs to the Event Receiver. Event
   Streams are unidirectional, with only one Event Transmitter and one Event
-  Receiver. Event Transmitters MAY support multiple Event Streams for a
+  Receiver. Event Transmitters support only one Event Streams for a
   single Event Receiver.
 
 Event Stream Management Endpoint
@@ -110,13 +110,11 @@ delivered over the Event Stream. If omitted, Event Transmitters SHOULD make
 this set available to the Event Receiver via some other means (e.g.
 publishing it in online documentation).
 
-delivery_methods
-: A JSON object containing a set of name/value pairs, where the name is a
-URI identifying a SET delivery method as defined in [DELIVERY](#DELIVERY), and the
-value is a JSON object whose name/value pairs contain the additional
-configuration parameters for that SET delivery method. The value object may
-be an empty JSON object (e.g. `{}`) if the SET delivery method does not have
-any configuration parameters.
+delivery
+: A JSON object containing a set of name/value pairs specifying configuration
+parameters for the SET delivery method. The actual delivery method is
+identified by the special key "delivery_method" with the value being a URI as
+defined in [DELIVERY](#DELIVERY).
 
 ### Reading a Stream's Configuration
 An Event Receiver gets the current configuration of a stream by making an
@@ -144,13 +142,9 @@ Pragma: no-cache
 
 {
   "aud": "http://www.example.com",
-  "delivery_methods": {
-    "https://schemas.example.com/set/http-push": {
-      "url": "https://receiver.example.com/events/risc"
-    },
-    "https://schemas.example.com/set/http-pull": {
-      "url": "https://transmitter.example.com/events/risc"
-    }
+  "delivery": {
+    "delivery_method": "https://schemas.example.com/set/http-push",
+    "url": "https://receiver.example.com/events/risc"
   },
   "events": [
     "https://schemas.openid.net/risc/event-type/account-at-risk",

--- a/draft-scurtescu-secevent-simple-control-plane.md
+++ b/draft-scurtescu-secevent-simple-control-plane.md
@@ -32,7 +32,7 @@ normative:
 
 Security Event Token (SET) delivery requires event receivers to indicate
 to event transmitters the subjects about which they wish to receive
-events, and how they wish to them. This specification defines a REST
+events, and how they wish to them. This specification defines an HTTP 
 API for a basic control plane that event transmitters can implement and
 event receivers may use to manage the flow of events from one to the
 other.

--- a/draft-scurtescu-secevent-simple-control-plane.md
+++ b/draft-scurtescu-secevent-simple-control-plane.md
@@ -26,10 +26,14 @@ author:
     email: richanna@amazon.com
     
 normative:
-  RFC7159:
+  JSON: RFC7159
   RFC7519:
-  set-delivery:
-    title: <<TODO>>
+  SET:
+    title: Security Event Token (SET)
+    target: https://tools.ietf.org/html/draft-ietf-secevent-token-01
+  DELIVERY:
+    title: SET Token Delivery Using HTTP
+    target: https://github.com/independentid/Identity-Events/blob/master/draft-hunt-secevent-delivery.txt
 
 --- abstract
 
@@ -51,6 +55,19 @@ Notational Conventions {#conv}
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
 "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
 document are to be interpreted as described in {{!RFC2119}}.
+
+Definitions {#def}
+===========
+In addition to terms defined in [SET](#SET), this
+specification uses the following terms:
+
+{: vspace="0"}
+Subject Identifier Object
+: A JSON object containing a set of one or more claims about a subject that
+  when taken together uniquely identify that subject. This set of claims
+  SHOULD be declared as an acceptable way to identify subjects of SETs by
+  one or more specifications that profile [SET](#SET).
+
 
 Control Plane Resources {#resources}
 =======================
@@ -92,7 +109,7 @@ requests to modify the stream's configuration.
 
 delivery_methods
 : A JSON object containing a set of name/value pairs, where the name is a
-URI identifying a SET delivery method as defined in [SET Delivery](#set-delivery), and
+URI identifying a SET delivery method as defined in [DELIVERY](#DELIVERY), and
 the value is a JSON object whose name/value pairs contain the additional
 configuration parameters for that SET delivery method. The value object may
 be an empty JSON object (e.g. `{}`) if the SET delivery method does not have
@@ -104,7 +121,7 @@ merge docs.>>
 ### Reading a Stream's Configuration
 An event receiver gets the current configuration of a stream by making
 an HTTP GET request to the stream resource. On receiving a valid request
-the event transmitter responds with a 200 OK response containing a [JSON](#RFC7159)
+the event transmitter responds with a 200 OK response containing a {{!JSON}}
 representation of the stream's configuration in the body.
 
 The following is a non-normative example request to read a stream's
@@ -155,22 +172,15 @@ event transmitter may transmit events over the stream. Event receivers
 can manipulate this set to manage which subjects they may receive events
 about over the stream.
 
-As the nature of the subject of a SET is left up to profiling
-specifications to define, subject identifiers are out of scope for this
-specification. Profiling specifications MUST define one or more subject
-properties that a receiver can include in their requests in order to
-identify the subject the request pertains to. 
-
 ### Adding a Subject to a Stream
-When a receiver wants to signal to a transmitter that they wish to
-receive events about a particular subject over a stream, the receiver
-makes an HTTP POST request to the `/add-subjects` endpoint under the
-stream's resource, containing in the body a JSON object whose name/value
-pairs contain subject identifiers defined by a profiling specification. The
-transmitter MAY choose to ignore the request, for example if the subject has
-previously indicated to the transmitter that they do not want events to be
-transmitted to the receiver. On a successful response, the transmitter
-responds with an empty 200 OK response.
+When a receiver wants to signal to a transmitter that they wish to receive
+events about a particular subject over a stream, the receiver makes an HTTP
+POST request to the `/add-subjects` endpoint under the stream's resource,
+containing in the body a Subject Identifier Object identifying the subject
+to be added. The transmitter MAY choose to ignore the request, for example
+if the subject has previously indicated to the transmitter that they do not
+want events to be transmitted to the receiver. On a successful response, the
+transmitter responds with an empty 200 OK response.
 
 <<TODO: MUST transmitters indicate that they are ignoring the request?>>
 
@@ -205,10 +215,9 @@ Pragma: no-cache
 When a receiver wants to signal to a transmitter that the receiver no
 longer wishes to receive events about a subject over a stream, the
 receiver makes an HTTP POST request to the `/remove-subject` endpoint under
-the stream's resource, containing in the body a JSON object whose name/value
-pairs contain subject identifiers defined by a profiling specification. The
-On a successful response, the transmitter responds with a 204 No Content
-response.
+the stream's resource, containing in the body a Subject Identifier Object
+identifying the subject to be removed. On a successful response, the
+transmitter responds with a 204 No Content response.
 
 <<TODO: Errors>>
 

--- a/draft-scurtescu-secevent-simple-control-plane.md
+++ b/draft-scurtescu-secevent-simple-control-plane.md
@@ -168,8 +168,8 @@ configuration:
 GET /set/stream HTTP/1.1
 Host: transmitter.example.com
 Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
-
 ~~~
+{: #figstatusreq title="Example: Stream Status Request"}
 
 The following is a non-normative example response:
 
@@ -197,6 +197,7 @@ Pragma: no-cache
   ]
 }
 ~~~
+{: #figstatusresp title="Example: Stream Status Response"}
 
 Subjects {#subjects}
 --------------------
@@ -240,6 +241,7 @@ Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
   "email": "example.user@example.com"
 }
 ~~~
+{: #figaddreq title="Example: Add Subject Request"}
 
 The following is a non-normative example response to a successful request:
 
@@ -248,8 +250,8 @@ HTTP/1.1 200 OK
 Server: transmitter.example.com
 Cache-Control: no-store
 Pragma: no-cache
-
 ~~~
+{: #figaddresp title="Example: Add Subject Response"}
 
 ### Removing a Subject
 To remove a subject from an Event Stream, the Event Receiver makes an HTTP
@@ -280,6 +282,7 @@ Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
   "phone_number": "123-456-7890"
 }
 ~~~
+{: #figremovereq title="Example: Remove Subject Request"}
 
 The following is a non-normative example response to a successful request:
 
@@ -288,8 +291,8 @@ HTTP/1.1 204 No Content
 Server: transmitter.example.com
 Cache-Control: no-store
 Pragma: no-cache
-
 ~~~
+{: #figremoveresp title="Example: Remove Subject Response"}
 
 Verification {#verify}
 ----------------------
@@ -345,6 +348,7 @@ Content-Type: application/json; charset=UTF-8
   "state": "VGhpcyBpcyBhbiBleGFtcGxlIHN0YXRlIHZhbHVlLgo="
 }
 ~~~
+{: #figverifyreq title="Example: Trigger Verification Request"}
 
 The following is a non-normative example response to a successful request:
 
@@ -353,8 +357,8 @@ HTTP/1.1 204 No Content
 Server: transmitter.example.com
 Cache-Control: no-store
 Pragma: no-cache
-
 ~~~
+{: #figverifyresp title="Example: Trigger Verification Response"}
 
 And the following is a non-normative example of a verification event sent to
 the Event Receiver as a result of the above request:
@@ -371,8 +375,8 @@ the Event Receiver as a result of the above request:
     },
   ],
 }
-
 ~~~
+{: #figverifyset title="Example: Verification SET"}
 
 --- back
 


### PR DESCRIPTION
As per email:

1. In section 1 the Event Stream definition states at the end that "Event Transmitters MAY support multiple Event Streams for a single Event Receiver." I propose that we restrict to only one stream between a given transmitter and receiver. This simplifies things quite a bit and there was no clear reason why multiple are needed. This issue came up during face to face meetings at the last IETF.

2. Somewhat related to the above, in 4.1.1 I think there should be only one delivery method configured.

3. Instead of defining a base endpoint then several endpoints on sub-paths I think we should rather define 4 endpoints.

4. Error responses could all be defined simply as HTTP status codes for now (401 - invalid auth, 400 - bad request, 404 - user not found, 429/503 - for receiver to slow down), makes sense?

5. In both add remove examples I think we should use only "email" and "phone_number" claims, and not "iss"+"sub" since as we understand today sub will never be used.


Also, added:
- short intro
- sample verification event showing nested state attribute
- tagged all examples with figure anchors and titles